### PR TITLE
Support React 19

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - '@swc/core'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,10 +35,12 @@ export default defineConfig({
             fileName: 'index',
         },
         rollupOptions: {
-            external: ['react', 'react-dom'],
+            external: ['react', 'react-dom', 'react/jsx-runtime'],
             output: {
                 globals: {
                     react: 'React',
+                    'react-dom': 'ReactDOM',
+                    'react/jsx-runtime': 'React',
                 },
             },
             plugins: [],


### PR DESCRIPTION
The previous build config would include the jsx runtime, packaging the React 18 version, making it incompatible with React 19. This explicitly disallows packaging the runtime. I tested this locally.

I also updated to support the latest pnpm.